### PR TITLE
Switch to AsyncKeyedLock

### DIFF
--- a/src/Ellie/Ellie.csproj
+++ b/src/Ellie/Ellie.csproj
@@ -23,6 +23,7 @@
             <PrivateAssets>all</PrivateAssets>
             <Publish>True</Publish>
         </PackageReference>
+        <PackageReference Include="AsyncKeyedLock" Version="6.1.1" />
         <PackageReference Include="AWSSDK.S3" Version="3.7.9.25" />
         <PackageReference Include="CodeHollow.FeedReader" Version="1.2.4" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />


### PR DESCRIPTION
Will greatly reduce memory allocations through pooling and will also clean up (currently the code leaves the dictionary _voiceGatewayLocks full and doesn't clean up after it's ready).